### PR TITLE
Ajw improved orders

### DIFF
--- a/Controllers/OrdersController.cs
+++ b/Controllers/OrdersController.cs
@@ -187,12 +187,22 @@ namespace BangazonAPI.Controllers
 
             using (IDbConnection conn = Connection)
             {
-                int rows = await conn.ExecuteAsync(sql);
-                if (rows > 0)
+                if (CustomerAccountCheck(order))
                 {
-                    return new StatusCodeResult(StatusCodes.Status204NoContent);
+                    int rows = await conn.ExecuteAsync(sql);
+                    if (rows > 0)
+                    {
+                        return new StatusCodeResult(StatusCodes.Status204NoContent);
+                    } else
+                    {
+                        throw new Exception("No rows affected");
+                    }
+                } else
+                {
+                    throw new Exception("Customer Account not associated with customer on the order.");
                 }
-                throw new Exception("No rows affected");
+
+                
             }
         }
 

--- a/Controllers/OrdersController.cs
+++ b/Controllers/OrdersController.cs
@@ -151,29 +151,7 @@ namespace BangazonAPI.Controllers
         [HttpPost]
         public async Task<IActionResult> Post([FromBody] Order order)
         {
-            //order.CustomerAccountId = null;
-            //string sql = $@"INSERT INTO Orders
-            //(CustomerId)
-            //VALUES
-            //('{order.CustomerId}');
-            //SELECT MAX(Id) FROM Orders;";
-
-            //using (IDbConnection conn = Connection)
-            //{
-            //    if (ActiveOrders(order.CustomerId, order))
-            //    {
-            //        var createdOrder = (await conn.QueryAsync<int>(sql)).Single();
-            //        order.Id = createdOrder;
-            //        return CreatedAtRoute("GetSingleOrder", new { id = createdOrder }, order);
-            //    } else
-            //    {
-            //        return new StatusCodeResult(StatusCodes.Status400BadRequest);
-            //    }
-
-            //}
-
             return await OrdersHandler(order);
-
         }
 
         // PUT: /Orders/5

--- a/Controllers/OrdersController.cs
+++ b/Controllers/OrdersController.cs
@@ -238,5 +238,16 @@ namespace BangazonAPI.Controllers
                 return conn.Query<Order>(sql).Count() == 0;
             }
         }
+
+        private bool CustomerAccountCheck(Order order)
+        {
+            string sql = $@"SELECT *
+                            FROM CustomerAccounts ca
+                            WHERE ca.Id = {order.CustomerAccountId} AND {order.CustomerId} = ca.CustomerId;";
+            using (IDbConnection conn = Connection)
+            {
+                return conn.Query<CustomerAccount>(sql).Count() > 0;
+            }
+        }
     }
 }

--- a/Models/Order.cs
+++ b/Models/Order.cs
@@ -23,6 +23,8 @@ namespace BangazonAPI.Models
 
         public Customer Customer { get; set; }
 
+        public int ProductId { get; set; }
+
 
   }
 }


### PR DESCRIPTION
# Name - Adding OrderProducts with Order Post

## Description

On creation of an order an OrderedProduct object must be created in the OrderedProducts table.

If a customer has no active Orders, create both an Order and OrderedProduct

If customer has an active Order, add the OrderedProduct to the correct order.

If the ProductId is not supplied with the order, return a bad request status code (400)

## Steps to Test
Attempt to POST to a user with an active order. An OrderedProduct will be added to the OrderedProducts table for the associated Order. OrderedProduct object will be returned.

Attempt to POST with a customer that doesn't have an active order. Order and OrderedProduct will be created and the new order will be returned

Attempt to POST will a `Order.ProductId of <= 0`     A bad request will be returned.

Attempt to POST a new Order for a customer with no active orders and set the `CustomerAccountId` on the Order to an int. The new Order will be returned with the `CustomerAccountId = null`

##### System configuration.
PC
##### 3rd party libraries that need to be installed.
Dapper
##### Command line utilities to run.
`dotnet run`
##### Link to Feature Ticket
#38 